### PR TITLE
Let assertions be consistency

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -12,18 +12,24 @@ matrix:
     fast_finish: true
     include:
         # Minimum supported dependencies with the latest and oldest PHP version
+        - php: 7.1
+          env: COMPOSER_FLAGS="--prefer-stable --prefer-lowest"
         - php: 7.2
           env: COMPOSER_FLAGS="--prefer-stable --prefer-lowest"
         - php: 7.3
+          env: COMPOSER_FLAGS="--prefer-stable --prefer-lowest"
+        - php: 7.4
           env: COMPOSER_FLAGS="--prefer-stable --prefer-lowest"
 
           # Test the latest stable release
+        - php: 7.1
         - php: 7.2
         - php: 7.3
+        - php: 7.4
           env: COVERAGE=true PHPUNIT_FLAGS="-v --coverage-text --coverage-clover=coverage.xml"
 
           # Latest commit to master
-        - php: 7.3
+        - php: 7.4
           env: STABILITY="dev"
 
     allow_failures:

--- a/composer.json
+++ b/composer.json
@@ -18,7 +18,7 @@
         "webmozart/assert": "^1.4"
     },
     "require-dev": {
-        "phpunit/phpunit": "^8.2",
+        "phpunit/phpunit": "^7.0",
         "php-http/message-factory": "^1.0",
         "php-http/curl-client": "^1.6",
         "php-http/message": "^1.0",

--- a/src/Api/Match.php
+++ b/src/Api/Match.php
@@ -5,9 +5,9 @@ declare(strict_types=1);
 namespace HappyrMatch\ApiClient\Api;
 
 use HappyrMatch\ApiClient\Exception;
-use HappyrMatch\ApiClient\Model\Match\GroupMatch;
 use HappyrMatch\ApiClient\Model\Match\CandidateMatch;
 use HappyrMatch\ApiClient\Model\Match\GroupFilter;
+use HappyrMatch\ApiClient\Model\Match\GroupMatch;
 use Psr\Http\Message\ResponseInterface;
 use Webmozart\Assert\Assert;
 

--- a/src/Api/Role.php
+++ b/src/Api/Role.php
@@ -5,8 +5,8 @@ declare(strict_types=1);
 namespace HappyrMatch\ApiClient\Api;
 
 use HappyrMatch\ApiClient\Exception;
-use HappyrMatch\ApiClient\Model\Role\Role as Model;
 use HappyrMatch\ApiClient\Model\Accepted;
+use HappyrMatch\ApiClient\Model\Role\Role as Model;
 use HappyrMatch\ApiClient\Model\Role\RoleCategoryCollection;
 use Psr\Http\Message\ResponseInterface;
 use Webmozart\Assert\Assert;

--- a/tests/HttpClientConfiguratorTest.php
+++ b/tests/HttpClientConfiguratorTest.php
@@ -26,14 +26,14 @@ final class HttpClientConfiguratorTest extends TestCase
 
         $hcc->appendPlugin($plugin0);
         $plugins = NSA::getProperty($hcc, 'appendPlugins');
-        static::assertCount(1, $plugins);
-        static::assertEquals($plugin0, $plugins[0]);
+        $this->assertCount(1, $plugins);
+        $this->assertEquals($plugin0, $plugins[0]);
 
         $plugin1 = new HeaderAppendPlugin(['plugin1']);
         $hcc->appendPlugin($plugin1);
         $plugins = NSA::getProperty($hcc, 'appendPlugins');
-        static::assertCount(2, $plugins);
-        static::assertEquals($plugin1, $plugins[1]);
+        $this->assertCount(2, $plugins);
+        $this->assertEquals($plugin1, $plugins[1]);
     }
 
     public function testAppendPluginMultiple()
@@ -44,9 +44,9 @@ final class HttpClientConfiguratorTest extends TestCase
 
         $hcc->appendPlugin($plugin0, $plugin1);
         $plugins = NSA::getProperty($hcc, 'appendPlugins');
-        static::assertCount(2, $plugins);
-        static::assertEquals($plugin0, $plugins[0]);
-        static::assertEquals($plugin1, $plugins[1]);
+        $this->assertCount(2, $plugins);
+        $this->assertEquals($plugin0, $plugins[0]);
+        $this->assertEquals($plugin1, $plugins[1]);
     }
 
     public function testPrependPlugin()
@@ -56,14 +56,14 @@ final class HttpClientConfiguratorTest extends TestCase
 
         $hcc->prependPlugin($plugin0);
         $plugins = NSA::getProperty($hcc, 'prependPlugins');
-        static::assertCount(1, $plugins);
-        static::assertEquals($plugin0, $plugins[0]);
+        $this->assertCount(1, $plugins);
+        $this->assertEquals($plugin0, $plugins[0]);
 
         $plugin1 = new HeaderAppendPlugin(['plugin1']);
         $hcc->prependPlugin($plugin1);
         $plugins = NSA::getProperty($hcc, 'prependPlugins');
-        static::assertCount(2, $plugins);
-        static::assertEquals($plugin1, $plugins[0]);
+        $this->assertCount(2, $plugins);
+        $this->assertEquals($plugin1, $plugins[0]);
     }
 
     public function testPrependPluginMultiple()
@@ -74,8 +74,8 @@ final class HttpClientConfiguratorTest extends TestCase
 
         $hcc->prependPlugin($plugin0, $plugin1);
         $plugins = NSA::getProperty($hcc, 'prependPlugins');
-        static::assertCount(2, $plugins);
-        static::assertEquals($plugin0, $plugins[0]);
-        static::assertEquals($plugin1, $plugins[1]);
+        $this->assertCount(2, $plugins);
+        $this->assertEquals($plugin0, $plugins[0]);
+        $this->assertEquals($plugin1, $plugins[1]);
     }
 }

--- a/tests/Model/Match/CandidateMatchTest.php
+++ b/tests/Model/Match/CandidateMatchTest.php
@@ -29,6 +29,6 @@ final class CandidateMatchTest extends BaseModelTest
 }
 JSON;
         $model = CandidateMatch::createFromArray(\json_decode($json, true));
-        self::assertEquals('1c227a66-92da-4192-bb0b-5103ed64b6a8', $model->getId());
+        $this->assertEquals('1c227a66-92da-4192-bb0b-5103ed64b6a8', $model->getId());
     }
 }

--- a/tests/Model/Match/GroupFilterTest.php
+++ b/tests/Model/Match/GroupFilterTest.php
@@ -49,9 +49,9 @@ final class GroupFilterTest extends BaseModelTest
 }
 JSON;
         $model = GroupFilter::createFromArray(\json_decode($json, true));
-        self::assertCount(5, $model->getCandidates());
-        self::assertInstanceOf(Group::class, $model->getGroup());
-        self::assertEquals('65fc109f-a19b-467b-9c15-83920eeaa2b6', $model->getGroup()->getId());
+        $this->assertCount(5, $model->getCandidates());
+        $this->assertInstanceOf(Group::class, $model->getGroup());
+        $this->assertEquals('65fc109f-a19b-467b-9c15-83920eeaa2b6', $model->getGroup()->getId());
     }
 
     public function testCreateWithoutGroup()
@@ -75,7 +75,7 @@ JSON;
 }
 JSON;
         $model = GroupFilter::createFromArray(\json_decode($json, true));
-        self::assertCount(5, $model->getCandidates());
-        self::assertNull($model->getGroup());
+        $this->assertCount(5, $model->getCandidates());
+        $this->assertNull($model->getGroup());
     }
 }

--- a/tests/Model/Match/GroupMatchTest.php
+++ b/tests/Model/Match/GroupMatchTest.php
@@ -4,8 +4,8 @@ declare(strict_types=1);
 
 namespace HappyrMatch\ApiClient\Tests\Model\Role;
 
-use HappyrMatch\ApiClient\Model\Match\GroupMatch;
 use HappyrMatch\ApiClient\Model\Match\CandidateMatch;
+use HappyrMatch\ApiClient\Model\Match\GroupMatch;
 use HappyrMatch\ApiClient\Tests\Model\BaseModelTest;
 
 /**
@@ -41,8 +41,8 @@ final class GroupMatchTest extends BaseModelTest
 }
 JSON;
         $model = GroupMatch::createFromArray(\json_decode($json, true));
-        self::assertCount(2, $model);
-        self::assertInstanceOf(CandidateMatch::class, $model[0]);
-        self::assertEquals('d503d4bf-8ab6-47fa-ab61-7c935e8cee4c', $model[0]->getId());
+        $this->assertCount(2, $model);
+        $this->assertInstanceOf(CandidateMatch::class, $model[0]);
+        $this->assertEquals('d503d4bf-8ab6-47fa-ab61-7c935e8cee4c', $model[0]->getId());
     }
 }

--- a/tests/Model/Role/RoleCategoryCollectionTest.php
+++ b/tests/Model/Role/RoleCategoryCollectionTest.php
@@ -39,8 +39,8 @@ final class RoleCategoryCollectionTest extends BaseModelTest
 }
 JSON;
         $model = RoleCategoryCollection::createFromArray(\json_decode($json, true));
-        self::assertCount(2, $model);
-        self::assertInstanceOf(RoleCategory::class, $model[0]);
-        self::assertEquals('e286921e-acf4-4a29-988f-59faedc98f2b', $model[0]->getId());
+        $this->assertCount(2, $model);
+        $this->assertInstanceOf(RoleCategory::class, $model[0]);
+        $this->assertEquals('e286921e-acf4-4a29-988f-59faedc98f2b', $model[0]->getId());
     }
 }

--- a/tests/Model/Role/RoleTest.php
+++ b/tests/Model/Role/RoleTest.php
@@ -17,7 +17,7 @@ final class RoleTest extends BaseModelTest
         $json =
             <<<'JSON'
 {
-    "data": 
+    "data":
         {
             "type": "role",
             "id": "e286921e-acf4-4a29-988f-59faedc98f2b",
@@ -26,6 +26,6 @@ final class RoleTest extends BaseModelTest
 }
 JSON;
         $model = Role::createFromArray(\json_decode($json, true));
-        self::assertEquals('e286921e-acf4-4a29-988f-59faedc98f2b', $model->getId());
+        $this->assertEquals('e286921e-acf4-4a29-988f-59faedc98f2b', $model->getId());
     }
 }


### PR DESCRIPTION
# Changed log
- According to the [PHPUnit assertion reference](https://phpunit.readthedocs.io/en/8.4/assertions.html), the assertion is `$this` and `self`.
- Fix coding style.
- Downgrade the PHPUnit version to support the `php-7.1` version because this package requires `php-7.1` version at least.

To be consistency, using the `$this` to be for all assertions.