### PR TITLE
Server exception when refreshing token

### DIFF
--- a/src/Exception/Domain/AuthorizationServerException.php
+++ b/src/Exception/Domain/AuthorizationServerException.php
@@ -1,0 +1,11 @@
+<?php
+
+declare(strict_types=1);
+
+namespace HappyrMatch\ApiClient\Exception\Domain;
+
+use HappyrMatch\ApiClient\Exception\DomainException;
+
+class AuthorizationServerException extends \Exception implements DomainException
+{
+}

--- a/src/Http/AuthenticationPlugin.php
+++ b/src/Http/AuthenticationPlugin.php
@@ -4,6 +4,7 @@ declare(strict_types=1);
 
 namespace HappyrMatch\ApiClient\Http;
 
+use HappyrMatch\ApiClient\Exception\Domain\ServerException;
 use Http\Client\Common\Plugin;
 use Http\Promise\Promise;
 use Psr\Http\Message\RequestInterface;
@@ -41,6 +42,9 @@ final class AuthenticationPlugin implements Plugin
         $this->accessToken = \json_decode($accessToken, true);
     }
 
+    /**
+     * @throws ServerException
+     */
     public function handleRequest(RequestInterface $request, callable $next, callable $first): Promise
     {
         if (null === $this->accessToken || $request->hasHeader('Authorization')) {

--- a/src/Http/AuthenticationPlugin.php
+++ b/src/Http/AuthenticationPlugin.php
@@ -4,7 +4,7 @@ declare(strict_types=1);
 
 namespace HappyrMatch\ApiClient\Http;
 
-use HappyrMatch\ApiClient\Exception\Domain\ServerException;
+use HappyrMatch\ApiClient\Exception\Domain\AuthorizationServerException;
 use Http\Client\Common\Plugin;
 use Http\Promise\Promise;
 use Psr\Http\Message\RequestInterface;
@@ -43,7 +43,7 @@ final class AuthenticationPlugin implements Plugin
     }
 
     /**
-     * @throws ServerException
+     * @throws AuthorizationServerException
      */
     public function handleRequest(RequestInterface $request, callable $next, callable $first): Promise
     {

--- a/src/Http/Authenticator.php
+++ b/src/Http/Authenticator.php
@@ -4,7 +4,7 @@ declare(strict_types=1);
 
 namespace HappyrMatch\ApiClient\Http;
 
-use HappyrMatch\ApiClient\Exception\Domain\ServerException;
+use HappyrMatch\ApiClient\Exception\Domain\AuthorizationServerException;
 use HappyrMatch\ApiClient\RequestBuilder;
 use Http\Client\HttpClient;
 
@@ -73,7 +73,7 @@ final class Authenticator
     }
 
     /**
-     * @throws ServerException
+     * @throws AuthorizationServerException
      */
     public function refreshAccessToken(string $accessToken, string $refreshToken): ?string
     {
@@ -89,7 +89,7 @@ final class Authenticator
 
         $response = $this->httpClient->sendRequest($request);
         if ($response->getStatusCode() >= 500) {
-            throw new ServerException();
+            throw new AuthorizationServerException();
         }
         if (200 !== $response->getStatusCode()) {
             return null;

--- a/src/Http/Authenticator.php
+++ b/src/Http/Authenticator.php
@@ -4,6 +4,7 @@ declare(strict_types=1);
 
 namespace HappyrMatch\ApiClient\Http;
 
+use HappyrMatch\ApiClient\Exception\Domain\ServerException;
 use HappyrMatch\ApiClient\RequestBuilder;
 use Http\Client\HttpClient;
 
@@ -71,6 +72,9 @@ final class Authenticator
         return $this->accessToken;
     }
 
+    /**
+     * @throws ServerException
+     */
     public function refreshAccessToken(string $accessToken, string $refreshToken): ?string
     {
         $request = $this->requestBuilder->create('POST', '/oauth/token', [
@@ -84,6 +88,9 @@ final class Authenticator
         ]));
 
         $response = $this->httpClient->sendRequest($request);
+        if ($response->getStatusCode() >= 500) {
+            throw new ServerException();
+        }
         if (200 !== $response->getStatusCode()) {
             return null;
         }


### PR DESCRIPTION
If AuthenticationPlugin receives a 5xx error it now will throw a Domain\ServerException instead of just returning null.